### PR TITLE
- lower case the ID part of the optional arugment to the headers 'Mex…

### DIFF
--- a/mesh_client/__init__.py
+++ b/mesh_client/__init__.py
@@ -48,7 +48,7 @@ IG_INT_CA_CERT = pkg_resources.resource_filename('mesh_client', "nhs-ig-int-ca-b
 _OPTIONAL_HEADERS = {
     "workflow_id": "Mex-WorkflowID",
     "filename": "Mex-FileName",
-    "local_id": "Mex-LocalID",
+    "local_id": "Mex-Localid",
     "message_type": "Mex-MessageType",
     "process_id": "Mex-ProcessID",
     "subject": "Mex-Subject",


### PR DESCRIPTION
Lower case `LocalID` -> `Localid` as per NHS certification requirements.